### PR TITLE
add decorator as requirement

### DIFF
--- a/andeboxlib/actions/toxtest.py
+++ b/andeboxlib/actions/toxtest.py
@@ -24,7 +24,7 @@ skip_install = true
 allowlist_externals = andebox
 basepython = {sys.executable}
 deps =
-  andebox
+  andebox>=0.36
   ac211: ansible-core~=2.11.0
   ac212: ansible-core~=2.12.0
   ac213: ansible-core~=2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ ansible-core
 pyyaml>=5.4
 python-vagrant
 fabric
+decorator
 tox


### PR DESCRIPTION
- `fabric` fails to include in requirements.txt