### PR TITLE
yaml_doc: better rule mechanism

### DIFF
--- a/andeboxlib/actions/ansibletest.py
+++ b/andeboxlib/actions/ansibletest.py
@@ -45,7 +45,7 @@ class AnsibleTestAction(AndeboxAction):
     def run(self, context):
         try:
             with context.temp_tree() as temp_dir:
-                if context.args.requirements:
+                if context.args.requirements and context.type == context.COLLECTION:
                     context.install_requirements()
                 if context.args.exclude_from_ignore:
                     context.exclude_from_ignore()

--- a/andeboxlib/actions/ansibletest.py
+++ b/andeboxlib/actions/ansibletest.py
@@ -14,21 +14,21 @@ class AnsibleTestAction(AndeboxAction):
         dict(
             names=("--keep", "-k"),
             specs=dict(
-                action="store_true", help="Keep temporary directory after execution"
+                action="store_true", help="keep temporary directory after execution"
             ),
         ),
         dict(
             names=("--exclude-from-ignore", "-efi", "-ei"),
             specs=dict(
                 action="store_true",
-                help="Matching lines in ignore files will be filtered out",
+                help="matching lines in ignore files will be filtered out",
             ),
         ),
         dict(
             names=("--requirements", "-R"),
             specs=dict(
                 action="store_true",
-                help="Install integration_tests_dependencies from tests/requirements.yml prior",
+                help="install integration_tests_dependencies from tests/requirements.yml prior",
             ),
         ),
         dict(names=("ansible_test_params",), specs=dict(nargs="+")),

--- a/andeboxlib/actions/base.py
+++ b/andeboxlib/actions/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2021, Alexei Znamensky <russoz@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from ..context import Context
+from ..context import ConcreteContexts
 
 
 class AndeboxAction:
@@ -16,7 +16,7 @@ class AndeboxAction:
             action_parser.add_argument(*arg["names"], **arg["specs"])
         return action_parser
 
-    def run(self, context: Context) -> None:
+    def run(self, context: ConcreteContexts) -> None:
         raise NotImplementedError()
 
     def __str__(self):

--- a/andeboxlib/actions/docsite.py
+++ b/andeboxlib/actions/docsite.py
@@ -18,21 +18,21 @@ class DocsiteAction(AndeboxAction):
         dict(
             names=("--keep", "-k"),
             specs=dict(
-                help="Keep temporary collection directory after execution",
+                help="keep temporary collection directory after execution",
                 action="store_true",
             ),
         ),
         dict(
             names=("--open", "-o"),
             specs=dict(
-                help="Open browser pointing to main page after build",
+                help="open browser pointing to main page after build",
                 action="store_true",
             ),
         ),
         dict(
             names=("--dest-dir", "-d"),
             specs=dict(
-                help="Directory which should contain the docsite",
+                help="directory which should contain the docsite",
                 default=".builtdocs",
                 type=Path,
             ),

--- a/andeboxlib/actions/docsite.py
+++ b/andeboxlib/actions/docsite.py
@@ -6,6 +6,7 @@ import subprocess
 import webbrowser
 from pathlib import Path
 
+from ..context import CollectionContext
 from ..exceptions import AndeboxException
 from ..util import set_dir
 from .base import AndeboxAction
@@ -39,7 +40,11 @@ class DocsiteAction(AndeboxAction):
         ),
     ]
 
-    def run(self, context):
+    def run(self, context: CollectionContext):
+        if context.type != context.COLLECTION:
+            raise AndeboxException(
+                "Action 'docsite' must be executed in a collection context!"
+            )
         try:
             with context.temp_tree() as collection_dir:
                 os.makedirs(context.args.dest_dir, mode=0o755, exist_ok=True)

--- a/andeboxlib/actions/ignorefile.py
+++ b/andeboxlib/actions/ignorefile.py
@@ -127,6 +127,7 @@ class ResultLine:
         return "".join(r)
 
 
+# @TODO works only for collections because of the hardcoded path
 _ignore_path = os.path.join(".", "tests", "sanity")
 try:
     with os.scandir(os.path.join(_ignore_path)) as sanity_dir:

--- a/andeboxlib/actions/ignorefile.py
+++ b/andeboxlib/actions/ignorefile.py
@@ -150,42 +150,43 @@ class IgnoreLinesAction(AndeboxAction):
             specs=dict(
                 choices=_ignore_versions + ["-"],
                 help=(
-                    "Use the ignore file matching this Ansible version. "
-                    "The special value '-' may be specified to read "
-                    "from stdin instead. If not specified, will use all available files. "
-                    "If no choices are presented, the collection structure was not recognized."
+                    "use the ignore file matching this Ansible version; "
+                    "special value '-' may be specified to read "
+                    "from stdin instead; if not specified, will use all available files; "
+                    "if no choices are presented, the collection structure was not recognized"
                 ),
             ),
         ),
         dict(
             names=["--depth", "-d"],
-            specs=dict(type=int, help="Path depth for grouping files"),
+            specs=dict(type=int, help="path depth for grouping files"),
         ),
         dict(
             names=["--filter-files", "-ff"],
             specs=dict(
-                type=re.compile, help="Regexp matching file names to be included"
+                type=re.compile,
+                help="regular expression matching file names to be included",
             ),
         ),
         dict(
             names=["--filter-checks", "-fc"],
             specs=dict(
                 type=re.compile,
-                help="Regexp matching checks in ignore files to be included",
+                help="regular expression matching checks in ignore files to be included",
             ),
         ),
         dict(
             names=["--suppress-files", "-sf"],
             specs=dict(
                 action="store_true",
-                help="Supress file names from the output, consolidating the results",
+                help="supress file names from the output, consolidating the results",
             ),
         ),
         dict(
             names=["--suppress-checks", "-sc"],
             specs=dict(
                 action="store_true",
-                help="Suppress the checks from the output, consolidating the results",
+                help="suppress the checks from the output, consolidating the results",
             ),
         ),
         dict(
@@ -194,7 +195,7 @@ class IgnoreLinesAction(AndeboxAction):
                 type=int,
                 default=10,
                 help=(
-                    "Number of lines to display in the output: leading lines if "
+                    "number of lines to display in the output: leading lines if "
                     "positive, trailing lines if negative, all lines if zero."
                 ),
             ),

--- a/andeboxlib/actions/runtime.py
+++ b/andeboxlib/actions/runtime.py
@@ -37,21 +37,21 @@ class RuntimeAction(AndeboxAction):
         dict(
             names=["--plugin-type", "-pt"],
             specs=dict(
-                choices=PLUGIN_TYPES, help="Specify the plugin type to be searched"
+                choices=PLUGIN_TYPES, help="specify the plugin type to be searched"
             ),
         ),
         dict(
             names=["--regex", "--regexp", "-r"],
             specs=dict(
-                action="store_true", help="Treat plugin names as regular expressions"
+                action="store_true", help="treat plugin names as regular expressions"
             ),
         ),
         dict(
             names=["--info-type", "-it"],
             specs=dict(
                 type=partial(info_type, RUNTIME_TYPES),
-                help=f"Restrict type of response elements. Must be in {RUNTIME_TYPES}, "
-                "may be shortened down to one letter.",
+                help=f"restrict type of response elements. Must be one of {RUNTIME_TYPES}, "
+                "and it may be shortened down to one letter.",
             ),
         ),
         dict(names=["plugin_names"], specs=dict(nargs="+")),

--- a/andeboxlib/actions/yaml_doc.py
+++ b/andeboxlib/actions/yaml_doc.py
@@ -338,12 +338,12 @@ class YAMLDocAction(AndeboxAction):
 
     # pylint: disable=attribute-defined-outside-init
     def run(self, context):
-        self.yaml = self.make_yaml_instance()
         self.offenders = context.args.offenders or context.args.fix_offenders
         self.fix_offenders = context.args.fix_offenders
         self.dry_run = context.args.dry_run
         self.width = context.args.width
         self.indent = self.calculate_indent(context.args.indent)
+        self.yaml = self.make_yaml_instance()
 
         for file_path in context.args.files:
             self.process_file(file_path)

--- a/andeboxlib/actions/yaml_doc.py
+++ b/andeboxlib/actions/yaml_doc.py
@@ -21,12 +21,12 @@ except ImportError:
 from .base import AndeboxAction
 
 
-FIXME_TAG = "__FIXEME__"
+FIXME_TAG = "__FIXME__"
 
 
 # pylint: disable=unused-argument
 def fixme(s):
-    return f"{FIXME_TAG}"
+    return f"{FIXME_TAG}({s})"
 
 
 DESCRIPTION_ACCEPTED_END_CHARS = (".", "!", ":", ";", ",", "?")
@@ -41,6 +41,7 @@ OFFENDING_SPEC = [
     dict(regexp=r"\bversus\b", apply=fixme),
     dict(regexp=r"\bvs\.?\b", apply=fixme),
     dict(regexp=r"\bversa\b", apply=fixme),
+    dict(regexp=r"won't", replace="will not"),
     # dict(regexp=r"\b(?:[Ww]i|')ll\b", apply=fixme),
     dict(regexp=r"[a-zI]'ve", apply=lambda s: s.replace("'ve", " have")),
     dict(regexp=r"can't", replace="cannot"),
@@ -61,7 +62,7 @@ OFFENDING_SPEC = [
     dict(regexp=r"\s(?:[Jj]son|[Dd]ns)[\s\.,]", apply=str.upper),
 ]
 OFFENDING_SPEC = [
-    (re.compile(f"(.*)({x['regexp']})({x.get('plural', '')})(.*)"), x)
+    (re.compile(f"(.*[^(])({x['regexp']})({x.get('plural', '')})([^)]?.*)"), x)
     for x in OFFENDING_SPEC
 ]
 

--- a/andeboxlib/actions/yaml_doc.py
+++ b/andeboxlib/actions/yaml_doc.py
@@ -21,22 +21,44 @@ except ImportError:
 from .base import AndeboxAction
 
 
+def fixme(s):
+    return "__FIXME__"
+
+
 DESCRIPTION_ACCEPTED_END_CHARS = (".", "!", ":", ";", ",", "?")
-OFFENDING_REGEXPS = [
-    re.compile(exp)
-    for exp in [
-        r"`",
-        r"\bi\.e\.?\b",  # i.e
-        r"\be\.g\.?\b",  # e.g.
-        r"[^/]etc\b",  # etc, but not /etc
-        r"\bvia\b",  # via
-        r"\bversus\b",
-        r"\bvs\.?\b",
-        r"\bversa\b",
-        r"\b[Ww]ill\b" r"[a-zI]'(re|t|d|ll|ve)",
-        r"(there|let|he)'s",
-        r"\s([Aa]pis?|[Jj]son|[Ii]ps?|[Dd]ns|[Ii]d)[\s\.,]",
-    ]
+OFFENDING_SPEC = [
+    # processed in order, apply only the first hit
+    # if using parenthesis in regexp, they MUST be non-capturing, as in (?:pattern1|pattern2|...)
+    dict(regexp=r"`", apply=fixme),
+    dict(regexp=r"\bi\.e\.?\b", apply=fixme),  # i.e
+    dict(regexp=r"\be\.g\.?\b", apply=fixme),  # e.g.
+    dict(regexp=r"[^/]etc\b", apply=fixme),  # etc, but not /etc
+    dict(regexp=r"\bvia\b", apply=fixme),  # via
+    dict(regexp=r"\bversus\b", apply=fixme),
+    dict(regexp=r"\bvs\.?\b", apply=fixme),
+    dict(regexp=r"\bversa\b", apply=fixme),
+    # dict(regexp=r"\b(?:[Ww]i|')ll\b", apply=fixme),
+    dict(regexp=r"[a-zI]'ve", apply=lambda s: s.replace("'ve", " have")),
+    dict(regexp=r"can't", replace="cannot"),
+    dict(regexp=r"[a-zI]n't", apply=lambda s: s.replace("n't", " not")),
+    dict(regexp=r"[a-zI]'re", apply=lambda s: s.replace("'re", " are")),
+    dict(regexp=r"[a-zI]'d", apply=lambda s: s.replace("'d", " would")),
+    dict(regexp=r"let's", replace="let us"),
+    dict(
+        regexp=r"(?:there|s?he|it)'s (?:been|[dg]one)",
+        apply=lambda s: s.replace("'s", " has"),
+    ),
+    dict(regexp=r"(?:there|s?he|it)'s", apply=lambda s: s.replace("'s", " is")),
+    dict(
+        regexp=r"\s(?:[Aa]pi|[Ii]p|[Ii]d|[Uu]r[il])",
+        plural=r"s?[\s\.,]",
+        apply=str.upper,
+    ),
+    dict(regexp=r"\s(?:[Jj]son|[Dd]ns)[\s\.,]", apply=str.upper),
+]
+OFFENDING_SPEC = [
+    (re.compile(f"(.*)({x['regexp']})({x.get('plural', '')})(.*)"), x)
+    for x in OFFENDING_SPEC
 ]
 
 
@@ -44,87 +66,6 @@ class YAMLDocException(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__()
         self.args = args
-
-
-def fix_desc_value(line: str) -> str:
-    line = line.strip()  # remove extraneous whitespace chars from heads and tails
-    line = re.sub(r"\s\s+", " ", line)
-    if not line[0].isupper():
-        line = line[0].upper() + line[1:]
-    if line.endswith(".)"):
-        return f"{line[:-2]})."
-    if line.endswith(DESCRIPTION_ACCEPTED_END_CHARS):
-        return line
-    return f"{line}."
-
-
-def process_description(desc: Union[List[str], str]) -> Union[List[str], str]:
-    try:
-        if isinstance(desc, str):
-            return fix_desc_value(desc)
-        else:  # assume list
-            return [fix_desc_value(x) for x in desc]
-    except Exception as e:
-        raise YAMLDocException(desc) from e
-
-
-def process_options(opts: Dict[str, Any], suboptions_kw: str) -> Dict[str, Any]:
-    try:
-        for option in opts.values():
-            if "description" in option:
-                option["description"] = process_description(option["description"])
-            if suboptions_kw in option:
-                option[suboptions_kw] = process_options(
-                    option[suboptions_kw], suboptions_kw
-                )
-        return opts
-    except Exception as e:
-        raise YAMLDocException(opts, suboptions_kw) from e
-
-
-def process_documentation(data: Dict[str, Any]) -> Dict[str, Any]:
-    try:
-        if data.get("short_description", " ").endswith("."):
-            data["short_description"] = data["short_description"].rstrip(".")
-        if desc := data.get("description"):
-            data["description"] = process_description(desc)
-        if notes := data.get("notes"):
-            data["notes"] = process_description(notes)
-        if seealso := data.get("seealso"):
-            for sa in seealso:
-                if sa_desc := sa.get("description"):
-                    sa["description"] = process_description(sa_desc)
-        if options := data.get("options"):
-            data["options"] = process_options(options, "suboptions")
-
-        return data
-    except Exception as e:
-        raise YAMLDocException(data) from e
-
-
-def process_return(data: Dict[str, Dict]) -> Dict[str, Dict]:
-    try:
-        data = process_options(data, "contains")
-        return data
-    except Exception as e:
-        raise YAMLDocException(data) from e
-
-
-def get_processor(variable: str, in_doc_fragments: bool = False) -> Callable:
-    processors_map = {
-        "DOCUMENTATION": process_documentation,
-        "RETURN": process_return,
-    }
-    return processors_map.get(
-        variable, process_documentation if in_doc_fragments else lambda x: x
-    )
-
-
-def report_offenders(content: List[str], content_first_line: int) -> None:
-    for num, line in enumerate(content):
-        if any(offender.search(line) for offender in OFFENDING_REGEXPS):
-            # both vars come from enumerate(), which starts at 0, so must add 2
-            print(f"  {2 + content_first_line + num:4}: {line}")
 
 
 class YAMLDocAction(AndeboxAction):
@@ -135,7 +76,14 @@ class YAMLDocAction(AndeboxAction):
             names=("--offenders", "-o"),
             specs=dict(
                 action="store_true",
-                help="Notifies of potential style-related offending constructs",
+                help="Report potential style-related offending constructs",
+            ),
+        ),
+        dict(
+            names=("--fix-offenders", "-O"),
+            specs=dict(
+                action="store_true",
+                help="Fix potential style-related offending constructs, implies (--offenders)",
             ),
         ),
         dict(
@@ -143,6 +91,13 @@ class YAMLDocAction(AndeboxAction):
             specs=dict(
                 action="store_true",
                 help="Do not modify files",
+            ),
+        ),
+        dict(
+            names=("--width", "-w"),
+            specs=dict(
+                action="store_true",
+                help="Width for the YAML output",
             ),
         ),
         dict(
@@ -155,7 +110,43 @@ class YAMLDocAction(AndeboxAction):
         ),
     ]
 
-    def make_yaml(self) -> YAML:
+    def apply_offender_rule(self, line_num: int, line: str) -> str:
+        for regexp, spec in OFFENDING_SPEC:
+            if match := regexp.match(line):
+                if self.offenders and not self.fix_offenders:
+                    print(f"  {line_num:4}: {line}")
+                prefix, term, plural, suffix = match.groups()
+
+                if func := spec.get("apply"):
+                    mod_line = f"{prefix}{func(term)}{plural}{suffix}"
+                    return mod_line
+                elif repl := spec.get("replace"):
+                    mod_line = f"{prefix}{repl}{plural}{suffix}"
+                    return mod_line
+
+        # Nothing found, return line as-is
+        return line
+
+    def process_offenders(self, content: List[str]) -> List[str]:
+        result = []
+        for num, line in enumerate(content):
+
+            line_num = 2 + self.first_line_no + num
+
+            def apply(line):
+                return self.apply_offender_rule(line_num, line)
+
+            prev_line = fixed_line = line
+            while (fixed_line := apply(fixed_line)) != prev_line:
+                prev_line = fixed_line
+
+            if fixed_line != line:
+                print(f"  {line_num:4}: {fixed_line}")
+            result.append(fixed_line)
+
+        return result
+
+    def make_yaml_instance(self) -> YAML:
         if not HAS_RUAMEL:
             raise ValueError("This action requires ruamel.yaml to be installed")
 
@@ -177,9 +168,79 @@ class YAMLDocAction(AndeboxAction):
         self.yaml.dump(data, output)
         return output.getvalue()
 
-    def process_yaml_block(
-        self, quoted_content: List[str], processor: Callable, dry_run: bool
-    ) -> List[str]:
+    def fix_desc_str(self, line: str) -> str:
+        line = line.strip()  # remove extraneous whitespace chars from heads and tails
+        line = re.sub(r"\s\s+", " ", line)
+        if not line[0].isupper():
+            line = line[0].upper() + line[1:]
+        if line.endswith(".)"):
+            return f"{line[:-2]})."
+        if line.endswith(DESCRIPTION_ACCEPTED_END_CHARS):
+            return line
+        return f"{line}."
+
+    def process_description(self, desc: Union[List[str], str]) -> Union[List[str], str]:
+        try:
+            if isinstance(desc, str):
+                return self.fix_desc_str(desc)
+            else:  # assume list
+                return [self.fix_desc_str(x) for x in desc]
+        except Exception as e:
+            raise YAMLDocException(desc) from e
+
+    def process_options(
+        self, opts: Dict[str, Any], suboptions_kw: str
+    ) -> Dict[str, Any]:
+        try:
+            for option in opts.values():
+                if "description" in option:
+                    option["description"] = self.process_description(
+                        option["description"]
+                    )
+                if suboptions_kw in option:
+                    option[suboptions_kw] = self.process_options(
+                        option[suboptions_kw], suboptions_kw
+                    )
+            return opts
+        except Exception as e:
+            raise YAMLDocException(opts, suboptions_kw) from e
+
+    def process_documentation(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            if data.get("short_description", " ").endswith("."):
+                data["short_description"] = data["short_description"].rstrip(".")
+            if desc := data.get("description"):
+                data["description"] = self.process_description(desc)
+            if notes := data.get("notes"):
+                data["notes"] = self.process_description(notes)
+            if seealso := data.get("seealso"):
+                for sa in seealso:
+                    if sa_desc := sa.get("description"):
+                        sa["description"] = self.process_description(sa_desc)
+            if options := data.get("options"):
+                data["options"] = self.process_options(options, "suboptions")
+
+            return data
+        except Exception as e:
+            raise YAMLDocException(data) from e
+
+    def process_return(self, data: Dict[str, Dict]) -> Dict[str, Dict]:
+        try:
+            data = self.process_options(data, "contains")
+            return data
+        except Exception as e:
+            raise YAMLDocException(data) from e
+
+    def get_processor(self, variable: str, in_doc_fragments: bool = False) -> Callable:
+        processors_map = {
+            "DOCUMENTATION": self.process_documentation,
+            "RETURN": self.process_return,
+        }
+        return processors_map.get(
+            variable, self.process_documentation if in_doc_fragments else lambda x: x
+        )
+
+    def process_yaml(self, quoted_content: List[str], processor: Callable) -> List[str]:
 
         data = self.read_yaml("\n".join(quoted_content))
         if not data:
@@ -197,13 +258,11 @@ class YAMLDocAction(AndeboxAction):
             yaml_content = yaml_content[1:]
 
         # Do the YAML parsing in dry run, but return the original content
-        if dry_run:
+        if self.dry_run:
             return quoted_content
         return yaml_content
 
-    def reformat_yaml_in_python_file(
-        self, file_path: Path, offenders: bool, dry_run: bool
-    ):
+    def process_file(self, file_path: Path):
         QUOTE_RE_FRAG = r'(?:"|\'){3}'
         VAR_RE_FRAG = r"(?:[A-Z]+)"
         ONELINE_RE = re.compile(
@@ -221,7 +280,7 @@ class YAMLDocAction(AndeboxAction):
         in_variable = ""
         first_line = ""
         quoted_content = []
-        first_line_no = 0
+        self.first_line_no = 0
 
         for line_no, line in enumerate(lines):
             line = line.rstrip()
@@ -231,19 +290,20 @@ class YAMLDocAction(AndeboxAction):
                     continue
 
                 updated_lines.append(first_line)
-                outbound_content = self.process_yaml_block(
+                outbound_content = self.process_yaml(
                     quoted_content,
-                    get_processor("DOCUMENTATION" if is_doc_frag else in_variable),
-                    dry_run,
+                    self.get_processor("DOCUMENTATION" if is_doc_frag else in_variable),
                 )
-                if offenders and in_variable != "EXAMPLES":
-                    report_offenders(outbound_content, first_line_no)
+                if self.offenders and in_variable != "EXAMPLES":
+                    fixed_content = self.process_offenders(outbound_content)
+                    if self.fix_offenders:
+                        outbound_content = fixed_content
                 updated_lines.extend(outbound_content)
                 updated_lines.append('"""')
 
                 in_variable = ""
                 quoted_content = []
-                first_line_no = 0
+                self.first_line_no = 0
 
             else:
                 if ONELINE_RE.search(line):
@@ -251,18 +311,20 @@ class YAMLDocAction(AndeboxAction):
                 elif match := FIRST_LINE_RE.search(line):
                     in_variable, yaml_first_line = match.groups()
                     first_line = f'{in_variable} = r"""{yaml_first_line}'
-                    first_line_no = line_no
+                    self.first_line_no = line_no
                 else:
                     updated_lines.append(line)
 
-        if not dry_run:
+        if not self.dry_run:
             # Write the updated lines back to the file
             with open(file_path, "w") as file:
                 file.writelines([f"{x}\n" for x in updated_lines])
 
     def run(self, context):
-        self.yaml = self.make_yaml()
+        self.yaml = self.make_yaml_instance()
+        self.offenders = context.args.offenders or context.args.fix_offenders
+        self.fix_offenders = context.args.fix_offenders
+        self.dry_run = context.args.dry_run
+
         for file_path in context.args.files:
-            self.reformat_yaml_in_python_file(
-                file_path, context.args.offenders, context.args.dry_run
-            )
+            self.process_file(file_path)

--- a/andeboxlib/cli.py
+++ b/andeboxlib/cli.py
@@ -17,7 +17,7 @@ from .actions.yaml_doc import YAMLDocAction
 from .actions.runtime import RuntimeAction
 from .actions.toxtest import ToxTestAction
 from .actions.vagrant import VagrantAction
-from .context import Context
+from .context import create_context
 from .exceptions import AndeboxException
 from .util import set_dir
 
@@ -65,7 +65,7 @@ class AndeBox:
 
     def run(self):
         args = self.parser.parse_args()
-        context = Context.create(args)
+        context = create_context(args)
         with set_dir(context.base_dir):
             action = self.actions[args.action]
             action.run(context)

--- a/andeboxlib/util.py
+++ b/andeboxlib/util.py
@@ -1,10 +1,12 @@
 import os
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
+from typing import Generator
 
 
 @contextmanager
-def set_dir(path):
+def set_dir(path: Path) -> Generator[Any, Any, Any]:
     previous = Path().absolute()
     try:
         os.chdir(path)


### PR DESCRIPTION
Offending elements can be fixed by yaml-doc. Its config is now a list of dicts, specifying:
  - regexp (mandatory)
  - apply (function to be applied to content)
  - replace (text to replace the content)

Additionally, this PR:
- add parameters `--width` and `--indent` to control the formatting of the output
- improve type checking
- improve consistency in CLI parameter help texts