### PR TITLE
test(coverage): do not generate coverage by default

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,5 @@ exclude_lines =
     if IMPORT_ERROR
 
 [run]
+source = andebox
 data_file = /tmp/.coverage

--- a/.github/workflows/ci-slow-tests.yml
+++ b/.github/workflows/ci-slow-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install --with dev,docs
 
       - name: Run all tests including slow
-        run: poetry run pytest -v --slow
+        run: poetry run pytest -v --cov --slow
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: poetry run flake8 -v . --count --show-source --statistics
 
       - name: Run tests
-        run: poetry run pytest -v --cov-branch
+        run: poetry run pytest -v --cov --cov-branch
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         PYTHONPATH: .
       run: |
         poetry run flake8 -v . --count --show-source --statistics
-        poetry run pytest -v
+        poetry run pytest - --cov
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@
 
 [pytest]
 addopts =
-    --cov=andebox
     --cov-report=term-missing
     --cov-report=html:htmlcov
     --cov-report=xml


### PR DESCRIPTION
That should streamline local builds, but the CI  workflows now run `pytest --cov` to force the generation of coverage information.