### PR TITLE
fix(action/yaml-doc): fix the rewrapping of long lines

### DIFF
--- a/andebox/actions/yaml_doc.py
+++ b/andebox/actions/yaml_doc.py
@@ -282,7 +282,7 @@ class AnsibleDocProcessor:
             return quoted_content
 
         data = processor(data)
-        yaml_content = self.dump_yaml(data).splitlines()
+        yaml_content = [s.rstrip() for s in self.dump_yaml(data).splitlines()]
 
         if isinstance(data, list):
             yaml_content = [

--- a/tests/test_action_yaml_doc.py
+++ b/tests/test_action_yaml_doc.py
@@ -183,6 +183,27 @@ TEST_CASES_MOCK = load_test_cases(
           U(https://andebox.readthedocs.io/en/latest/actions.html).
       options: {}
 
+# copied from community.general.office_365_connector_card
+- id: word-wrapper-rewrap-trailing-space
+  input:
+    DOCUMENTATION: |
+      module: office_365_connector_card
+      short_description: Use webhooks to create Connector Card messages within an Office 365 group
+      description:
+        - Creates Connector Card messages through Office 365 Connectors.
+        - See
+          U(https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#connector-card-for-microsoft-365-groups).
+      options: {}
+  expected:
+    DOCUMENTATION: |
+      module: office_365_connector_card
+      short_description: Use webhooks to create Connector Card messages within an Office 365 group
+      description:
+        - Creates Connector Card messages through Office 365 Connectors.
+        - See
+          U(https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#connector-card-for-microsoft-365-groups).
+      options: {}
+
 # testcase copied from the EXAMPLES section of the connection plugin community.general.wsl
 - id: multiple-docs-in-examples
   input:


### PR DESCRIPTION
When a long line is already split in two, ruamel.yaml seems to be adding a trailing space to the first line.