### PR TITLE
ci: stop generating coverage for normal (fast) runs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -75,9 +75,3 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest -v --cov --cov-branch
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true


### PR DESCRIPTION
The coverage is generated in the "Slow" runs, which test more than the regular ones.