### PR TITLE
docs: update test subcommand examples for typer idiom

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ No need to clone in specific locations or keep track of env variables. Simply cl
 run the `ansible-test` command as:
 
 ```
-$ andebox test -- sanity --docker default --test validate-modules plugins/modules/mymodule.py
-$ andebox test -- units --docker default test/units/plugins/modules/mymodule.py
-$ andebox test -- integration --docker default mymodule
+$ andebox test sanity -- --docker default --test validate-modules plugins/modules/mymodule.py
+$ andebox test units -- --docker default test/units/plugins/modules/mymodule.py
+$ andebox test integration -- --docker default mymodule
 ```
 
 If you want to test your code against multiple versions of `ansible-core` or other component, you


### PR DESCRIPTION
## Summary

- Update `andebox test` README examples to place the test type argument before `--`, matching the typer/Click convention (`andebox test sanity -- --docker ...` instead of `andebox test -- sanity --docker ...`)

## Test plan

- [ ] Visual inspection of rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)