### PR TITLE
fix: add support for -- in CLI

### DIFF
--- a/andebox/actions/ansibletest.py
+++ b/andebox/actions/ansibletest.py
@@ -62,7 +62,9 @@ def ansible_test_cmd(
         )
         raise typer.Exit(2)
 
-    params = ansible_test_params or []
+    params = list(ansible_test_params or [])
+    if params[:1] == ["--"]:
+        params = params[1:]
 
     with andebox_context(ctx, make_temp_tree=True, keep=keep) as context:
         if context.type == ContextType.COLLECTION and not skip_requirements:

--- a/andebox/actions/toxtest.py
+++ b/andebox/actions/toxtest.py
@@ -109,8 +109,11 @@ def tox_test_cmd(
             cmd_args.append("-r")
         if env:
             cmd_args.extend(["-e", env])
+        params = list(ansible_test_params or [])
+        if params[:1] == ["--"]:
+            params = params[1:]
         cmd_args.append("--")
-        cmd_args.extend(ansible_test_params or [])
+        cmd_args.extend(params)
         rc = subprocess.call(cmd_args)
 
         if rc != 0:

--- a/andebox/actions/vagrant.py
+++ b/andebox/actions/vagrant.py
@@ -90,7 +90,10 @@ def vagrant_cmd(
                         if context.venv
                         else str(venv / "bin" / "andebox")
                     )
-                    cmd = f"{andebox_path} --venv {venv} test -- integration {' '.join(integration_test_params or [])}"
+                    vparams = list(integration_test_params or [])
+                    if vparams[:1] == ["--"]:
+                        vparams = vparams[1:]
+                    cmd = f"{andebox_path} --venv {venv} test -- integration {' '.join(vparams)}"
                     if sudo:
                         cmd = "sudo -HE " + cmd
 


### PR DESCRIPTION
With the adoption of typer it was no longer interpreted as a separator of arguments but rather passed literally to the underlying command, causing error.