### PR TITLE
test: add tests for toxtest and vagrant actions

### DIFF
--- a/tests/test_action_toxtest.py
+++ b/tests/test_action_toxtest.py
@@ -1,0 +1,148 @@
+# code: language=python tabSize=4
+#
+# (C) 2026 Alexei Znamensky
+# Licensed under the MIT License. See LICENSES/MIT.txt for details.
+# SPDX-FileCopyrightText: 2026 Alexei Znamensky
+# SPDX-License-Identifier: MIT
+#
+import pytest
+
+from andebox.actions.toxtest import TOX_INI_FILENAME, _make_default_tox_ini
+
+from .utils import GenericTestCase, load_test_cases, verify_return_code
+
+
+def _make_collection(path):
+    (path / "meta").mkdir(parents=True)
+    (path / "meta" / "runtime.yml").write_text("requires_ansible: '>=2.18'\n")
+    (path / "galaxy.yml").write_text("namespace: test\nname: coll\nversion: 1.0.0\n")
+
+
+TEST_CASES = load_test_cases(
+    f"""
+- id: no-opts
+  input:
+    args: [tox-test]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "--"]
+
+- id: list
+  input:
+    args: [tox-test, --list]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "-a", "--"]
+
+- id: recreate
+  input:
+    args: [tox-test, --recreate]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "-r", "--"]
+
+- id: env
+  input:
+    args: [tox-test, --env, ac218]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "-e", "ac218", "--"]
+
+- id: params
+  input:
+    args: [tox-test, sanity]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "--", "sanity"]
+
+- id: params-with-sep
+  input:
+    args: [tox-test, --, sanity]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "--", "sanity"]
+
+- id: all-opts
+  input:
+    args: [tox-test, --list, --recreate, --env, ac219]
+  expected:
+    rc: 0
+    cmd: ["tox", "-c", "{TOX_INI_FILENAME}", "-a", "-r", "-e", "ac219", "--"]
+
+- id: nonzero-rc
+  input:
+    args: [tox-test]
+    subprocess_rc: 1
+  expected:
+    rc: 1
+
+- id: tox-ini-not-overwritten
+  input:
+    args: [tox-test]
+    existing_tox_ini: |
+      [tox]
+      # custom
+  expected:
+    rc: 0
+    tox_ini_content: |
+      [tox]
+      # custom
+"""
+)
+
+TEST_CASES_IDS = [tc.id for tc in TEST_CASES]
+
+
+def test_make_default_tox_ini_structure():
+    content = _make_default_tox_ini()
+    assert "[tox]" in content
+    assert "envlist" in content
+    assert "[testenv]" in content
+    assert "andebox test" in content
+
+
+def test_make_default_tox_ini_envs():
+    content = _make_default_tox_ini()
+    for env in ("ac218", "ac219", "ac220", "ac221", "dev"):
+        assert env in content
+
+
+@pytest.mark.parametrize("testcase", TEST_CASES, ids=TEST_CASES_IDS)
+def test_toxtest_command(make_helper, testcase, run_andebox, tmp_path, mocker):
+    def setup(tc):
+        _make_collection(tmp_path)
+        if existing := tc.input.get("existing_tox_ini"):
+            (tmp_path / TOX_INI_FILENAME).write_text(existing)
+        mock_call = mocker.patch(
+            "andebox.actions.toxtest.subprocess.call",
+            return_value=tc.input.get("subprocess_rc", 0),
+        )
+        return {"basedir": tmp_path, "mock_call": mock_call}
+
+    def verify_cmd(tc):
+        expected_cmd = tc.expected.get("cmd")
+        if expected_cmd:
+            assert tc.data["mock_call"].call_args[0][0] == expected_cmd
+
+    def verify_tox_ini(tc):
+        expected_content = tc.expected.get("tox_ini_content")
+        if expected_content is not None:
+            assert (tmp_path / TOX_INI_FILENAME).read_text() == expected_content
+
+    test = make_helper(testcase, setup, run_andebox, [verify_return_code, verify_cmd, verify_tox_ini])
+    test.run()
+
+
+def test_tox_ini_created_when_missing(make_helper, run_andebox, tmp_path, mocker):
+    testcase = GenericTestCase(id="creates-ini", input={"args": ["tox-test"]}, expected={})
+
+    def setup(tc):
+        _make_collection(tmp_path)
+        mocker.patch("andebox.actions.toxtest.subprocess.call", return_value=0)
+        return {"basedir": tmp_path}
+
+    def verify_created(tc):
+        assert (tmp_path / TOX_INI_FILENAME).exists()
+
+    test = make_helper(testcase, setup, run_andebox, verify_created)
+    test.run()

--- a/tests/test_action_vagrant.py
+++ b/tests/test_action_vagrant.py
@@ -1,0 +1,159 @@
+# code: language=python tabSize=4
+#
+# (C) 2026 Alexei Znamensky
+# Licensed under the MIT License. See LICENSES/MIT.txt for details.
+# SPDX-FileCopyrightText: 2026 Alexei Znamensky
+# SPDX-License-Identifier: MIT
+#
+from unittest.mock import MagicMock
+
+import pytest
+
+from .utils import GenericTestCase, load_test_cases, verify_return_code
+
+
+def _make_collection(path):
+    (path / "meta").mkdir(parents=True)
+    (path / "meta" / "runtime.yml").write_text("requires_ansible: '>=2.18'\n")
+    (path / "galaxy.yml").write_text("namespace: test\nname: coll\nversion: 1.0.0\n")
+
+
+def _make_vagrant_mocks(mocker):
+    mock_vagrant_cls = mocker.patch("vagrant.Vagrant")
+    mock_v = mock_vagrant_cls.return_value
+    mock_v.up.return_value = iter([])
+    mock_v.user.return_value = "vagrant"
+    mock_v.hostname.return_value = "127.0.0.1"
+    mock_v.port.return_value = 2222
+    mock_v.keyfile.return_value = "/tmp/key"
+
+    mock_conn_cls = mocker.patch("andebox.actions.vagrant.Connection")
+    mock_c = mock_conn_cls.return_value.__enter__.return_value
+    mock_c.cd.return_value = MagicMock()
+    mock_c.cd.return_value.__enter__ = MagicMock(return_value=None)
+    mock_c.cd.return_value.__exit__ = MagicMock(return_value=False)
+
+    return mock_v, mock_c
+
+
+TEST_CASES = load_test_cases(
+    """
+- id: basic-run
+  input:
+    args: [vagrant]
+  expected:
+    rc: 0
+    up_vm_name: default
+    destroy_called: false
+
+- id: custom-vm-name
+  input:
+    args: [vagrant, --name, myvm]
+  expected:
+    rc: 0
+    up_vm_name: myvm
+
+- id: sudo
+  input:
+    args: [vagrant, --sudo]
+  expected:
+    rc: 0
+    cmd_starts_with: "sudo -HE "
+
+- id: destroy
+  input:
+    args: [vagrant, --destroy]
+  expected:
+    rc: 0
+    destroy_called: true
+
+- id: missing-vagrantfile
+  input:
+    args: [vagrant]
+    has_vagrantfile: false
+  expected:
+    rc: 1
+
+- id: import-error
+  input:
+    args: [vagrant]
+    import_error: "No module named vagrant"
+  expected:
+    rc: 1
+
+- id: connection-error
+  input:
+    args: [vagrant]
+    connection_error: "SSH connection failed"
+  expected:
+    rc: 1
+"""
+)
+
+TEST_CASES_IDS = [tc.id for tc in TEST_CASES]
+
+
+@pytest.mark.parametrize("testcase", TEST_CASES, ids=TEST_CASES_IDS)
+def test_vagrant_command(make_helper, testcase, run_andebox, tmp_path, mocker):
+    def setup(tc):
+        _make_collection(tmp_path)
+
+        if import_error_msg := tc.input.get("import_error"):
+            mocker.patch("andebox.actions.vagrant.IMPORT_ERROR", ImportError(import_error_msg))
+            return {"basedir": tmp_path}
+
+        mock_v, mock_c = _make_vagrant_mocks(mocker)
+
+        if connection_error_msg := tc.input.get("connection_error"):
+            mock_conn_cls = mocker.patch("andebox.actions.vagrant.Connection")
+            mock_conn_cls.return_value.__enter__.side_effect = RuntimeError(connection_error_msg)
+
+        if tc.input.get("has_vagrantfile", True):
+            (tmp_path / "Vagrantfile").write_text("# Vagrantfile\n")
+
+        return {"basedir": tmp_path, "mock_v": mock_v, "mock_c": mock_c}
+
+    def verify_up_vm_name(tc):
+        up_vm_name = tc.expected.get("up_vm_name")
+        if up_vm_name and "mock_v" in tc.data:
+            tc.data["mock_v"].up.assert_called_once_with(vm_name=up_vm_name, stream_output=True)
+
+    def verify_cmd(tc):
+        cmd_starts_with = tc.expected.get("cmd_starts_with")
+        if cmd_starts_with and "mock_c" in tc.data:
+            cmd = tc.data["mock_c"].run.call_args[0][0]
+            assert cmd.startswith(cmd_starts_with)
+
+    def verify_destroy(tc):
+        destroy_called = tc.expected.get("destroy_called")
+        if destroy_called is not None and "mock_v" in tc.data:
+            if destroy_called:
+                tc.data["mock_v"].destroy.assert_called_once()
+            else:
+                tc.data["mock_v"].destroy.assert_not_called()
+
+    test = make_helper(
+        testcase,
+        setup,
+        run_andebox,
+        [verify_return_code, verify_up_vm_name, verify_cmd, verify_destroy],
+    )
+    test.run()
+
+
+def test_vagrant_run_contains_integration(make_helper, run_andebox, tmp_path, mocker):
+    testcase = GenericTestCase(id="run-integration", input={"args": ["vagrant"]}, expected={})
+
+    def setup(tc):
+        _make_collection(tmp_path)
+        mock_v, mock_c = _make_vagrant_mocks(mocker)
+        (tmp_path / "Vagrantfile").write_text("# Vagrantfile\n")
+        return {"basedir": tmp_path, "mock_c": mock_c}
+
+    def verify_integration(tc):
+        cmd = tc.data["mock_c"].run.call_args[0][0]
+        assert "andebox" in cmd
+        assert "integration" in cmd
+
+    test = make_helper(testcase, setup, run_andebox, verify_integration)
+    test.run()


### PR DESCRIPTION
## Summary

- Add `tests/test_action_toxtest.py` with 12 tests covering `_make_default_tox_ini`, tox.ini file creation/preservation, all CLI option combinations, and error handling
- Add `tests/test_action_vagrant.py` with 8 tests covering import-error detection, missing Vagrantfile, command construction (sudo, destroy, custom VM name), and connection error wrapping

Both test files use mocking (`pytest-mock` + `typer.testing.CliRunner`) so they run without requiring real tox environments or Vagrant VMs.

Closes #216

## Test plan

- [x] `poetry run pytest tests/test_action_toxtest.py tests/test_action_vagrant.py -v` — 20/20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)