### PR TITLE
ci: fix Dependabot devcontainers ecosystem directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
           - "patch"
 
   - package-ecosystem: "devcontainers"
-    directory: ".devcontainer"
+    directory: "/"
     schedule:
       interval: "weekly"
     rebase-strategy: auto


### PR DESCRIPTION
The `devcontainers` Dependabot ecosystem was configured with `directory: ".devcontainer"`. Dependabot interprets that as the directory *containing* the devcontainer config, so it searched `/.devcontainer` for a nested `.devcontainer/devcontainer.json` (or `.devcontainer.json`), found neither, and aborted the whole update run with `dependency_file_not_found`.

Setting `directory: "/"` points it at the repo root, where it correctly locates `.devcontainer/devcontainer.json`. This also makes the entry consistent with the `pip` and `github-actions` ecosystems, which already use `"/"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)