### PR TITLE
test: drop brittle stdout line-count assertion in runtime test

### DIFF
--- a/tests/test_action_runtime.py
+++ b/tests/test_action_runtime.py
@@ -35,7 +35,6 @@ TEST_CASES = load_test_cases(
   expected:
     in_stdout: >
       R modules postgresql_query: redirected to community.postgresql.postgresql_query
-    stdout_line_count: 4
 - id: redirects-callbacks-endswith-y
   input:
     repo: {GIT_REPO_CG}


### PR DESCRIPTION
`test_action_runtime[redirects-endswith-y]` asserted `stdout_line_count: 4` on the output of `andebox runtime --regex -it redirect 'y$'`, which greps a fresh `--depth 1` clone of `community.general` `main`. Upstream has since added more `redirect` entries whose target ends in `y`, so the exact count no longer matches and the assertion fails.

This broke every job that runs the suite: **Test andebox**, **Weekly Slow Tests**, and **Semantic Release** (which gates `build`/`release` on it, so releases were blocked too).

Removing the exact-count assertion for this case. The `in_stdout` substring check on the same case still exercises the code path; only the fragile pin against a moving upstream file is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)